### PR TITLE
Use text/plain instead of the wrong plain/text

### DIFF
--- a/src/main/java/org/geoserver/shell/ScriptCommands.java
+++ b/src/main/java/org/geoserver/shell/ScriptCommands.java
@@ -72,7 +72,7 @@ public class ScriptCommands implements CommandMarker {
             @CliOption(key = "file", mandatory = true, help = "The script File") File file
     ) throws Exception {
         String url = geoserver.getUrl() + "/rest/scripts/wps/" + URLUtil.encode(name);
-        String result = HTTPUtils.put(url, file, "plain/text", geoserver.getUser(), geoserver.getPassword());
+        String result = HTTPUtils.put(url, file, "text/plain", geoserver.getUser(), geoserver.getPassword());
         return result != null;
     }
 

--- a/src/main/java/org/geoserver/shell/TemplateCommands.java
+++ b/src/main/java/org/geoserver/shell/TemplateCommands.java
@@ -95,7 +95,7 @@ public class TemplateCommands implements CommandMarker {
             urlBuilder.append(URLUtil.encode(file.getName()));
         }
         // @ToDo Should this be post?
-        String result = HTTPUtils.put(urlBuilder.toString(), file, "plain/text", geoserver.getUser(), geoserver.getPassword());
+        String result = HTTPUtils.put(urlBuilder.toString(), file, "text/plain", geoserver.getUser(), geoserver.getPassword());
         return result != null;
     }
 
@@ -116,7 +116,7 @@ public class TemplateCommands implements CommandMarker {
         } else {
             urlBuilder.append(URLUtil.encode(file.getName()));
         }
-        String result = HTTPUtils.put(urlBuilder.toString(), file, "plain/text", geoserver.getUser(), geoserver.getPassword());
+        String result = HTTPUtils.put(urlBuilder.toString(), file, "text/plain", geoserver.getUser(), geoserver.getPassword());
         return result != null;
     }
 


### PR DESCRIPTION
Geoserver expects templates as text/plain per doc/en/api/1.0.0/templates.yaml#L336

When trying to create a new template, gs-shell would fail:
```
gs-shell>template create --file /tmp/content.ftl --workspace geor --datastore point_remarquable_relief --featuretype point_remarquable_relief --name content
false 
```
looking at the geoserver logs it returns a 415 for 'unknown media type' - indeed, the `Content-Type` header is wrong.

With this PR it works:
```
gs-shell>template create --file /tmp/content.ftl --workspace geor --datastore point_remarquable_relief --featuretype point_remarquable_relief --name content
true
```

And it matches what the swagger doc says for all template consume operations, cf https://github.com/geoserver/geoserver/blob/master/doc/en/api/1.0.0/templates.yaml#L384